### PR TITLE
Adds rate limiting to login requests.

### DIFF
--- a/api/handlers/send.go
+++ b/api/handlers/send.go
@@ -25,7 +25,13 @@ func (env *Env) Send(w http.ResponseWriter, r *http.Request) {
 
 	err = env.SendService.Send(input.Email)
 	if err != nil {
-		http.Error(w, "Internal error", http.StatusInternalServerError)
+		if err.Error() == "email address is rate limited" {
+			http.Error(w, "Too many requests", http.StatusTooManyRequests)
+			return
+		} else {
+			http.Error(w, "Internal error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	http.Error(w, "OK", http.StatusOK)

--- a/api/handlers/send_test.go
+++ b/api/handlers/send_test.go
@@ -45,6 +45,13 @@ var RequestLinkTestItems = []struct {
 		bodyData:     `{"email":"fail@datastore.error"}`,
 		expectStatus: 500,
 	},
+	{
+		comment:      "trigger rate limited response",
+		httpURL:      "http://localhost/requestlink/",
+		httpMethod:   "POST",
+		bodyData:     `{"email":"isratelimited@create.session"}`,
+		expectStatus: 429,
+	},
 }
 
 func TestMagicLinkRequestWeb(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -68,3 +68,13 @@ func (c *Config) SESSION_ID_LENGTH() int {
 func (c *Config) SESSION_EXPIRES_MINS() int {
 	return c.getEnvAsInt("SESSION_EXPIRES_MINS", 10080) // 1 week
 }
+
+// The maximum number of send requests, for a particulate email address
+func (c *Config) RATE_LIMIT_MAX_SEND_REQUESTS() int {
+	return c.getEnvAsInt("RATE_LIMIT_MAX_SEND_REQUESTS", 3)
+}
+
+// The number of minutes over which rate limiting applies, so max 3 send requests per 15 min period
+func (c *Config) RATE_LIMIT_TIME_PERIOD_MINS() int {
+	return c.getEnvAsInt("RATE_LIMIT_TIME_PERIOD_MINS", 15)
+}

--- a/kubernetes/magiclink.yaml
+++ b/kubernetes/magiclink.yaml
@@ -51,3 +51,7 @@ spec:
               value: "64"
             - name: "MAGICLINK_SESSION_EXPIRES_MINS"
               value: "10080"
+            - name: "RATE_LIMIT_MAX_SEND_REQUESTS"
+              value: "3"
+            - name: "RATE_LIMIT_TIME_PERIOD_MINS"
+              value: 15

--- a/pkg/datastore/redis/keys.go
+++ b/pkg/datastore/redis/keys.go
@@ -6,4 +6,6 @@ const (
 	linkSendQueue = "queue:send" // queue of objects for external notify process to send
 	authIDsKey    = "id"         // magic link ids used for authentication
 	sessionIDsKey = "session"
+
+	LoginRequestsKeyFormat = "loginRequests:%s"
 )

--- a/pkg/datastore/redis/sendrequest.go
+++ b/pkg/datastore/redis/sendrequest.go
@@ -2,7 +2,11 @@ package redis
 
 import (
 	"fmt"
+	"github.com/go-redis/redis/v8"
 	"github.com/thisdougb/magiclink/config"
+	"log"
+	"strconv"
+	"time"
 )
 
 func (d *Datastore) SubmitSendLinkRequest(data string) error {
@@ -25,4 +29,62 @@ func (d *Datastore) StoreAuthID(email string, id string, ttlSeconds int) error {
 	key := fmt.Sprintf("%s%s:%s", cfg.REDIS_KEY_PREFIX(), authIDsKey, id)
 
 	return d.setWithExpiry(key, email, ttlSeconds)
+}
+
+func (d *Datastore) GetLoginAttempts(email string, ttlMinutes int) ([]string, error) {
+
+	var cfg *config.Config // dynamic config settings
+
+	var logins []string
+
+	key := fmt.Sprintf(LoginRequestsKeyFormat, email)
+	key = fmt.Sprintf("%s%s", cfg.REDIS_KEY_PREFIX(), key)
+
+	now := time.Now().UnixNano() / 1e6             // convert to milliseconds
+	since := now - int64((ttlMinutes * 60 * 1000)) // convert to milliseconds
+
+	// begin with clean out old login attempts
+	since = since - 1
+	_, err := d.client.ZRemRangeByScore(d.ctx, key, strconv.FormatInt(0, 10), strconv.FormatInt(since, 10)).Result()
+	if err != nil {
+		return logins, err
+	}
+
+	// now read the logins
+	values, err := d.client.ZRangeByScore(d.ctx, key, &redis.ZRangeBy{
+		Min:    strconv.FormatInt(since, 10),
+		Max:    strconv.FormatInt(now, 10),
+		Offset: 0,
+		Count:  -1,
+	}).Result()
+	if err != nil {
+		log.Println("data.GetOwnerLogins(): ", err)
+		return logins, err
+	}
+
+	for _, value := range values {
+		logins = append(logins, value)
+	}
+
+	return logins, nil
+}
+
+func (d *Datastore) LogLoginAttempt(email string) error {
+
+	var cfg *config.Config // dynamic config settings
+
+	key := fmt.Sprintf(LoginRequestsKeyFormat, email)
+	key = fmt.Sprintf("%s%s", cfg.REDIS_KEY_PREFIX(), key)
+
+	timestamp := time.Now().UnixNano() / 1e6 // convert to milliseconds
+
+	_, err := d.client.ZAdd(d.ctx, key, &redis.Z{
+		Score:  float64(timestamp),
+		Member: time.Now().Format("Mon Jan _2 15:04:05 2006"),
+	}).Result()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/usecase/send/1_interface.go
+++ b/pkg/usecase/send/1_interface.go
@@ -8,9 +8,13 @@ type Repository interface {
 	Writer
 }
 
-type Reader interface{}
+type Reader interface {
+	GetLoginAttempts(email string, sinceMinutes int) ([]string, error)
+}
 
 type Writer interface {
 	SubmitSendLinkRequest(data string) error
 	StoreAuthID(email string, id string, ttlSeconds int) error
+
+	LogLoginAttempt(email string) error
 }

--- a/pkg/usecase/send/4_mock_reader.go
+++ b/pkg/usecase/send/4_mock_reader.go
@@ -2,6 +2,29 @@
 
 package send
 
-import ()
+import (
+	"errors"
+	"github.com/thisdougb/magiclink/config"
+)
 
 type MockReader struct{}
+
+func (m *MockReader) GetLoginAttempts(email string, sinceMinutes int) ([]string, error) {
+
+	var cfg *config.Config // dynamic config settings
+
+	logins := []string{}
+
+	if email == "getloginsattempts@datastore.error" {
+		return logins, errors.New("datastore error")
+	}
+
+	if email == "isratelimited@create.session" {
+		for i := 0; i <= cfg.RATE_LIMIT_MAX_SEND_REQUESTS()+1; i++ {
+			logins = append(logins, "test data")
+		}
+		return logins, nil
+	}
+
+	return logins, nil
+}

--- a/pkg/usecase/send/5_mock_writer.go
+++ b/pkg/usecase/send/5_mock_writer.go
@@ -27,3 +27,12 @@ func (m *MockWriter) StoreAuthID(email string, id string, ttlSeconds int) error 
 	}
 	return nil
 }
+
+func (m *MockWriter) LogLoginAttempt(email string) error {
+
+	if email == "logloginattempt@datastore.error" {
+		return errors.New("datastore error")
+	}
+
+	return nil
+}

--- a/pkg/usecase/send/main_test.go
+++ b/pkg/usecase/send/main_test.go
@@ -34,6 +34,21 @@ var TestItems = []struct {
 		email:         "StoreAuthID@datastore.error",
 		expectedError: errors.New("datastore error"),
 	},
+	{
+		comment:       "is rate limited",
+		email:         "isratelimited@create.session",
+		expectedError: errors.New("email address is rate limited"),
+	},
+	{
+		comment:       "getloginattempts datastore error",
+		email:         "getloginsattempts@datastore.error",
+		expectedError: errors.New("GetLoginAttempts datastore error"),
+	},
+	{
+		comment:       "LogLoginAttempt datastore error",
+		email:         "logloginattempt@datastore.error",
+		expectedError: errors.New("LogLoginAttempt datastore error"),
+	},
 }
 
 func TestRequestLink(t *testing.T) {


### PR DESCRIPTION
Rate limiting requests for a login link, by default not more than 3 requests per 15 minutes.