### PR TITLE
Session owner lookup protected endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ go run api/server.go
 2021/11/12 13:41:41 Adding handler for session owner endpoint: /session/owner/
 2021/11/12 13:41:41 magiclink.Start(): listening on port 8080
 ```
-With your configured token, you can now do a lookup to get the session owner.
+With the token, you can now do a lookup to get the session owner.
 ```
 $ curl --data '{"token":"Gyk185p9Aol28GJ6ncqUWo02uG57k9G0qo4vkno5FWRkyGT6dTXfzMFcfrhknzSW", \
                 "session":"gJlaNl84dnk7LHWuMyMUUG5sSHqOLnEdQcunTvKTSoEb7XYHbsecmhsB8wRO0TFm"}' \

--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -16,7 +16,7 @@ func (env *Env) Auth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	magiclinkid := strings.TrimPrefix(r.URL.Path, "/auth/")
+	magiclinkid := strings.TrimPrefix(r.URL.Path, env.GetURLPrefix()+"/auth/")
 
 	sessionID, err := env.AuthService.Auth(magiclinkid)
 	if err != nil {

--- a/api/handlers/auth_test.go
+++ b/api/handlers/auth_test.go
@@ -62,7 +62,7 @@ func TestAuthWeb(t *testing.T) {
 		rr := httptest.NewRecorder()
 		handler := http.HandlerFunc(env.Auth)
 
-		httpURL := fmt.Sprintf("http://localhost/auth/%s", item.MagicLinkID)
+		httpURL := fmt.Sprintf("http://localhost%s%s%s", env.GetURLPrefix(), "/auth/", item.MagicLinkID)
 
 		req, err := http.NewRequest(item.httpMethod, httpURL, nil)
 		if err != nil {

--- a/api/handlers/env.go
+++ b/api/handlers/env.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"github.com/thisdougb/magiclink/config"
 	"github.com/thisdougb/magiclink/pkg/usecase/auth"
+	"github.com/thisdougb/magiclink/pkg/usecase/owner"
 	"github.com/thisdougb/magiclink/pkg/usecase/send"
 	"log"
 	"net/http"
@@ -14,9 +16,10 @@ import (
 */
 
 type Env struct {
-	Logger      *log.Logger
-	SendService *send.Service
-	AuthService *auth.Service
+	Logger       *log.Logger
+	SendService  *send.Service
+	AuthService  *auth.Service
+	OwnerService *owner.Service
 }
 
 func (e *Env) createCookie(sessionName string, sessionID string, expiresAtTime time.Time) *http.Cookie {
@@ -30,4 +33,18 @@ func (e *Env) createCookie(sessionName string, sessionID string, expiresAtTime t
 	}
 
 	return &cookie
+}
+
+func (e *Env) GetURLPrefix() string {
+
+	var cfg *config.Config // dynamic config settings
+
+	urlPrefix := cfg.ValueAsStr("URL_PREFIX")
+
+	// strip trailing / from url prefix if it exists
+	urlPrefixLength := len(urlPrefix)
+	if urlPrefixLength > 0 && urlPrefix[urlPrefixLength-1] == '/' {
+		urlPrefix = urlPrefix[:urlPrefixLength-1]
+	}
+	return urlPrefix
 }

--- a/api/handlers/sessionowner.go
+++ b/api/handlers/sessionowner.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"encoding/json"
+	"github.com/thisdougb/magiclink/config"
+	"net/http"
+	"strings"
+)
+
+func (env *Env) Owner(w http.ResponseWriter, r *http.Request) {
+
+	var cfg *config.Config // dynamic config settings
+
+	if r.Method != "POST" {
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// define this close to its usage
+	var input struct {
+		Token   string
+		Session string
+	}
+
+	err := json.NewDecoder(r.Body).Decode(&input)
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// get access tokens currently allowed
+	accessTokens := strings.Split(cfg.ValueAsStr("SESSION_OWNER_ACCESS_TOKENS"), ",")
+	accessTokenValid := false
+	for _, token := range accessTokens {
+		if input.Token == token {
+			accessTokenValid = true
+			break
+		}
+	}
+	if !accessTokenValid {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	owner, err := env.OwnerService.SessionOwner(input.Session)
+	if err != nil || owner == "" {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+
+	var output struct {
+		Owner string
+	}
+
+	output.Owner = owner
+
+	outputBytes, err := json.Marshal(output)
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(outputBytes)
+}

--- a/api/handlers/sessionowner_test.go
+++ b/api/handlers/sessionowner_test.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/thisdougb/magiclink/pkg/usecase/owner"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// we can't really test the html output here
+var SessionOwnerTestItems = []struct {
+	comment        string
+	httpURL        string
+	httpMethod     string
+	bodyData       string
+	expectBodyData string
+	expectStatus   int
+}{
+	{
+		comment:        "valid request",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"12345","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   200,
+		expectBodyData: `{"Owner":"valid@session.owner"}`,
+	},
+	{
+		comment:        "invalid method",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "GET",
+		bodyData:       `{"token":"user@domain.com","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   405,
+		expectBodyData: "Method Not Allowed\n",
+	},
+	{
+		comment:        "invalid json input",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"user@domain.com","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"`,
+		expectStatus:   400,
+		expectBodyData: "Bad Request\n",
+	},
+	{
+		comment:        "invalid access token",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"11111","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   401,
+		expectBodyData: "Unauthorized\n",
+	},
+	{
+		comment:        "session not found",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"12345","session":"999991lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   404,
+		expectBodyData: "Not Found\n",
+	},
+}
+
+func TestSessionOwnerRequest(t *testing.T) {
+
+	os.Setenv("MAGICLINK_SESSION_OWNER_ACCESS_TOKENS", "12345")
+	defer os.Unsetenv("MAGICLINK_SESSION_OWNER_ACCESS_TOKENS")
+
+	// create our mock service
+	r := owner.NewMockRepository()
+	ownerService := owner.NewService(r)
+
+	// inject mock service
+	env := &Env{OwnerService: ownerService}
+
+	for _, item := range SessionOwnerTestItems {
+
+		// httptest lets us interrogate the http response
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(env.Owner)
+
+		bodyReader := bytes.NewReader([]byte(item.bodyData))
+
+		req, err := http.NewRequest(item.httpMethod, item.httpURL, bodyReader)
+		if err != nil {
+			assert.Fail(t, item.comment)
+		}
+		req.Header.Add("Content-Type", "encoding/json")
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, item.expectStatus, rr.Code, item.comment)
+		assert.Equal(t, item.expectBodyData, rr.Body.String(), item.comment)
+	}
+}
+
+// we can't really test the html output here
+var SessionMultipleTokenItems = []struct {
+	comment        string
+	httpURL        string
+	httpMethod     string
+	bodyData       string
+	expectBodyData string
+	expectStatus   int
+}{
+	{
+		comment:        "valid request first token",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"54321","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   200,
+		expectBodyData: `{"Owner":"valid@session.owner"}`,
+	},
+	{
+		comment:        "valid request second token",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"12345","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   200,
+		expectBodyData: `{"Owner":"valid@session.owner"}`,
+	},
+	{
+		comment:        "invalid access token",
+		httpURL:        "http://localhost/sessionowner/",
+		httpMethod:     "POST",
+		bodyData:       `{"token":"99999","session":"1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn"}`,
+		expectStatus:   401,
+		expectBodyData: "Unauthorized\n",
+	},
+}
+
+func TestMultipleAccessTokens(t *testing.T) {
+
+	// set multiple access tokens the service will accept,
+	// simulates rolling the token
+	os.Setenv("MAGICLINK_SESSION_OWNER_ACCESS_TOKENS", "54321,12345")
+	defer os.Unsetenv("MAGICLINK_SESSION_OWNER_ACCESS_TOKENS")
+
+	// create our mock service
+	r := owner.NewMockRepository()
+	ownerService := owner.NewService(r)
+
+	// inject mock service
+	env := &Env{OwnerService: ownerService}
+
+	for _, item := range SessionMultipleTokenItems {
+
+		// httptest lets us interrogate the http response
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(env.Owner)
+
+		bodyReader := bytes.NewReader([]byte(item.bodyData))
+
+		req, err := http.NewRequest(item.httpMethod, item.httpURL, bodyReader)
+		if err != nil {
+			assert.Fail(t, item.comment)
+		}
+		req.Header.Add("Content-Type", "encoding/json")
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, item.expectStatus, rr.Code, item.comment)
+		assert.Equal(t, item.expectBodyData, rr.Body.String(), item.comment)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ var defaultValues = map[string]interface{}{
 	"RATE_LIMIT_MAX_SEND_REQUESTS": 3,                  // max requests for a magic link within TIME_PERIOD
 	"RATE_LIMIT_TIME_PERIOD_MINS":  15,                 // time period within which we rate limit
 	"SESSION_OWNER_PROTECTED_URL":  "",                 // we can expose a protected URL to return session owner
-	"SESSION_OWNER_ACCESS_TOKEN":   "12345",            // access token to make api requests for session owner
+	"SESSION_OWNER_ACCESS_TOKENS":  "",                 // session owner access tokens - off by default
 }
 
 // Public methods here.

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 )
@@ -28,23 +29,34 @@ var defaultValues = map[string]interface{}{
 	"SESSION_EXPIRES_MINS":         10080,              // our cookie expires after this many minutes (1 week)
 	"RATE_LIMIT_MAX_SEND_REQUESTS": 3,                  // max requests for a magic link within TIME_PERIOD
 	"RATE_LIMIT_TIME_PERIOD_MINS":  15,                 // time period within which we rate limit
+	"SESSION_OWNER_PROTECTED_URL":  "",                 // we can expose a protected URL to return session owner
+	"SESSION_OWNER_ACCESS_TOKEN":   "12345",            // access token to make api requests for session owner
 }
 
 // Public methods here.
 // Use typed methods so we avoid type assertions at point of use.
 func (c *Config) ValueAsStr(key string) string {
 
+	c.mapHasKey(key) // check key exists
 	defaultValue := defaultValues[key].(string)
 	return c.getEnvVar(key, defaultValue).(string)
 }
 
 func (c *Config) ValueAsInt(key string) int {
 
+	c.mapHasKey(key) // check key exists
 	defaultValue := defaultValues[key].(int)
 	return c.getEnvVar(key, defaultValue).(int)
 }
 
 // Private methods here
+func (c *Config) mapHasKey(key string) bool {
+	if _, ok := defaultValues[key]; ok {
+		return true
+	}
+	log.Fatal("Config.mapHasKey: trying to access non-existant config key: ", key)
+	return false
+}
 func (c *Config) getEnvVar(key string, fallback interface{}) interface{} {
 
 	fullEnvVarName := fmt.Sprintf("%s%s", envVarPrefix, key)

--- a/kubernetes/magiclink.yaml
+++ b/kubernetes/magiclink.yaml
@@ -29,13 +29,15 @@ spec:
     spec:
       containers:
       - name: magiclink
-        image: thisdougb/magiclink:latest
+        image: thisdougb/magiclink:develop
         imagePullPolicy: Always
         ports:
             - containerPort: 8080
         env:
             - name: MAGICLINK_API_PORT
               value: "8080"
+            - name: MAGICLINK_URL_PREFIX
+              value: "/magiclink"
             - name: "MAGICLINK_REDIS_HOST"
               value: "redis"
             - name: "MAGICLINK_REDIS_PORT"

--- a/pkg/datastore/interface.go
+++ b/pkg/datastore/interface.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"github.com/thisdougb/magiclink/pkg/usecase/auth"
+	"github.com/thisdougb/magiclink/pkg/usecase/owner"
 	"github.com/thisdougb/magiclink/pkg/usecase/send"
 )
 
@@ -12,4 +13,5 @@ type DatastoreInterface interface {
 
 	send.Repository
 	auth.Repository
+	owner.Repository
 }

--- a/pkg/datastore/redis/gorediscmds.go
+++ b/pkg/datastore/redis/gorediscmds.go
@@ -35,3 +35,13 @@ func (d *Datastore) getExpire(key string) (string, error) {
 
 	return data, nil
 }
+
+func (d *Datastore) getValueAtKey(key string) (string, error) {
+
+	data, err := d.client.Get(d.ctx, key).Result()
+	if err != nil {
+		return "", err
+	}
+
+	return data, nil
+}

--- a/pkg/datastore/redis/session.go
+++ b/pkg/datastore/redis/session.go
@@ -1,0 +1,23 @@
+package redis
+
+import (
+	"fmt"
+	"github.com/thisdougb/magiclink/config"
+)
+
+func (d *Datastore) GetSessionOwner(sessionID string) (string, error) {
+
+	var cfg *config.Config // dynamic config settings
+
+	key := fmt.Sprintf("%s%s:%s", cfg.ValueAsStr("REDIS_KEY_PREFIX"), sessionIDsKey, sessionID)
+
+	data, err := d.getValueAtKey(key)
+	if err != nil {
+		if err.Error() == "redis: nil" { // not found
+			return "", nil
+		}
+		return "", err
+	}
+
+	return data, nil
+}

--- a/pkg/usecase/owner/1_interface.go
+++ b/pkg/usecase/owner/1_interface.go
@@ -1,0 +1,16 @@
+package owner
+
+import ()
+
+//Repository interface pattern
+type Repository interface {
+	Reader
+	Writer
+}
+
+type Reader interface {
+	GetSessionOwner(session string) (string, error)
+}
+
+type Writer interface {
+}

--- a/pkg/usecase/owner/2_service.go
+++ b/pkg/usecase/owner/2_service.go
@@ -1,0 +1,12 @@
+package owner
+
+// Service allows us to inject a mock repo
+type Service struct {
+	repo Repository
+}
+
+func NewService(r Repository) *Service {
+	return &Service{
+		repo: r,
+	}
+}

--- a/pkg/usecase/owner/3_mock.go
+++ b/pkg/usecase/owner/3_mock.go
@@ -1,0 +1,14 @@
+// +build dev test
+
+package owner
+
+import ()
+
+type MockRepository struct {
+	MockReader
+	MockWriter
+}
+
+func NewMockRepository() *MockRepository {
+	return &MockRepository{}
+}

--- a/pkg/usecase/owner/4_mock_reader.go
+++ b/pkg/usecase/owner/4_mock_reader.go
@@ -1,0 +1,21 @@
+// +build dev test
+
+package owner
+
+import (
+	"errors"
+)
+
+type MockReader struct {
+}
+
+func (m *MockReader) GetSessionOwner(session string) (string, error) {
+
+	if session == "1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn" {
+		return "valid@session.owner", nil
+	}
+	if session == "111111lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn" {
+		return "", errors.New("datastore error")
+	}
+	return "", nil
+}

--- a/pkg/usecase/owner/5_mock_writer.go
+++ b/pkg/usecase/owner/5_mock_writer.go
@@ -1,0 +1,11 @@
+// +build dev test
+
+package owner
+
+import ()
+
+type MockWriter struct{}
+
+//
+// Mock methods here, with conditionals enabling testing of return values
+//

--- a/pkg/usecase/owner/main.go
+++ b/pkg/usecase/owner/main.go
@@ -1,0 +1,27 @@
+package owner
+
+import (
+	"errors"
+	"github.com/idthings/alphanum"
+	"github.com/thisdougb/magiclink/config"
+	"log"
+)
+
+// Submit a Send task
+func (s *Service) SessionOwner(session string) (string, error) {
+
+	var cfg *config.Config // dynamic config settings
+
+	if !alphanum.IsValidAlphaNum(session, cfg.ValueAsInt("SESSION_ID_LENGTH")) {
+		log.Println("session id is invalid:", session)
+		return "", errors.New("invalid session id")
+	}
+
+	// lookup session id
+	owner, err := s.repo.GetSessionOwner(session)
+	if err != nil {
+		return "", err
+	}
+
+	return owner, nil
+}

--- a/pkg/usecase/owner/main_test.go
+++ b/pkg/usecase/owner/main_test.go
@@ -1,0 +1,43 @@
+// +build dev test
+
+package owner
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// using a test table
+var TestItems = []struct {
+	comment       string // a comment used to identify test in output
+	session       string // in our mock we use this value to affect the return values
+	expectedError error
+	expectedOwner string
+}{
+	{
+		comment:       "send valid session",
+		session:       "1tleL1lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn",
+		expectedError: nil,
+		expectedOwner: "valid@session.owner",
+	},
+	{
+		comment:       "trigger datastore error",
+		session:       "111111lgn0UDADpa1UhEcmga6x5j8YkFNRvhCAZNysxLQzzlmKgTP5wFvgdPfgPn",
+		expectedError: errors.New("datastore error"),
+		expectedOwner: "",
+	},
+}
+
+func TestRequestLink(t *testing.T) {
+
+	mockDatastore := NewMockRepository()
+	s := NewService(mockDatastore)
+
+	for _, item := range TestItems {
+
+		owner, err := s.SessionOwner(item.session)
+		assert.Equal(t, item.expectedOwner, owner, item.comment)
+		assert.Equal(t, item.expectedError, err, item.comment)
+	}
+}


### PR DESCRIPTION
Exporting these env vars turns this feature on at magiclink startup time.
```
$ export SESSION_OWNER_PROTECTED_URL='/session/owner/'
$ export SESSION_OWNER_ACCESS_TOKENS='Gyk185p9Aol28GJ6ncqUWo02uG57k9G0qo4vkno5FWRkyGT6dTXfzMFcfrhknzSW'
$
$ go run api/server.go
2021/11/12 13:41:41 Adding handler for session owner endpoint: /session/owner/
2021/11/12 13:41:41 magiclink.Start(): listening on port 8080
```
With the token, you can now do a lookup to get the session owner.
```
$ curl --data '{"token":"Gyk185p9Aol28GJ6ncqUWo02uG57k9G0qo4vkno5FWRkyGT6dTXfzMFcfrhknzSW", \
                "session":"gJlaNl84dnk7LHWuMyMUUG5sSHqOLnEdQcunTvKTSoEb7XYHbsecmhsB8wRO0TFm"}' \
        -X POST http://localhost:8080/magiclink/session/owner/

{"Owner":"someuser@somedomain.com"}
```